### PR TITLE
fix(tests): make harness state isolation the session default (#407)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
+import atexit
 import os
+import shutil
+import tempfile
 
 import pytest
 import pytest_asyncio
@@ -7,6 +10,42 @@ import structlog
 from migrations.env_utils import load_models
 from src._core.infrastructure.persistence.rdb.config import DatabaseConfig
 from src._core.infrastructure.persistence.rdb.database import Base, Database
+
+# Redirect every harness hook this session spawns away from the operator's live
+# state (#407).
+#
+# The eleven hook modules under `.agents/shared/`, `.claude/hooks/`,
+# `.codex/hooks/` and `.antigravity/hooks/` resolve their state directory as
+# `Path(os.environ.get("HARNESS_STATE_ROOT", REPO_ROOT))`. The default is the
+# real repository, so isolation is opt-in *per call site* — and a call site
+# that forgets it does not fail, it succeeds against production state. Eight
+# sites opted in; five files did not, and a routine `pytest tests/` overwrote
+# `.agents/state/current-work.json`, which the SessionStart hook reads back as
+# session context. A fixture prompt beginning `[trivial]` therefore surfaced,
+# one session later, as a process-gate waiver nobody had issued.
+#
+# Setting the variable here inverts that default for the whole session, and
+# covers both leak mechanisms:
+#
+#   * subprocess — `subprocess.run` without `env=` hands the child
+#     `os.environ`, so the child now inherits an isolated root;
+#   * in-process — a hook exec'd inside pytest via `importlib` writes through
+#     `work_ledger`, whose `STATE_ROOT` is a *module-level constant* bound on
+#     first import. A fixture would run too late to change it; this module is
+#     imported before any test module in `tests/`, so it is early enough.
+#
+# A call site that builds `env` from scratch inherits nothing and must still
+# pass the variable itself (or restore what it touches) — see
+# `tests/integration/test_stop_hook_e2e.py`. `tests/unit/agents_shared/
+# test_no_live_ledger_write.py` guards both ends.
+#
+# Not `setdefault`: an ambient `HARNESS_STATE_ROOT` pointing at the repository
+# would silently reinstate the bug, and no test asserts the unset default —
+# `tests/unit/agents_shared/test_work_ledger.py` patches module attributes
+# instead, which is immune to this.
+_HARNESS_STATE_ROOT = tempfile.mkdtemp(prefix="pytest-harness-state-")
+os.environ["HARNESS_STATE_ROOT"] = _HARNESS_STATE_ROOT
+atexit.register(shutil.rmtree, _HARNESS_STATE_ROOT, ignore_errors=True)
 
 # Populate ``Base.metadata`` with *every* model before any fixture touches the
 # schema (#374).

--- a/tests/integration/test_stop_hook_e2e.py
+++ b/tests/integration/test_stop_hook_e2e.py
@@ -29,6 +29,25 @@ _STATE_DIR = REPO_ROOT / ".codex" / "state"
 # even if a real session runs concurrently.
 _E2E_INFIX = "e2etest"
 
+_LEDGER_PATH = REPO_ROOT / ".agents" / "state" / "current-work.json"
+
+
+def _read_live_ledger() -> str | None:
+    """Exact bytes of the live work ledger, or ``None`` when it is absent."""
+    try:
+        return _LEDGER_PATH.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _restore_live_ledger(snapshot: str | None) -> None:
+    """Put the live work ledger back the way this test found it (#407)."""
+    if snapshot is None:
+        _LEDGER_PATH.unlink(missing_ok=True)
+        return
+    if _read_live_ledger() != snapshot:
+        _LEDGER_PATH.write_text(snapshot, encoding="utf-8")
+
 
 def test_stop_hook_e2e_marker_cleanup() -> None:
     """stop-sync-reminder.py must consume all exception-token markers on Stop."""
@@ -37,6 +56,14 @@ def test_stop_hook_e2e_marker_cleanup() -> None:
     now = time.time()
     stale_epoch = now - (48 * 3600)
     written: list[Path] = []
+    # The stripped env below is built from scratch, so this test inherits none
+    # of the session isolation that `tests/conftest.py` installs (#407) — and
+    # that is deliberate, because the markers under test live in the *real*
+    # `.codex/state/`. What is not deliberate is the rest of the Stop hook's
+    # work: it also calls `update_verification_from_git()`, which rewrites the
+    # operator's live `.agents/state/current-work.json`. Snapshot it and put it
+    # back, the same contract the marker cleanup below already honours.
+    ledger_before = _read_live_ledger()
 
     try:
         # 3 fresh markers (within 24 h — removed by IC-11 Option A bulk sweep)
@@ -110,3 +137,4 @@ def test_stop_hook_e2e_marker_cleanup() -> None:
         for marker in written:
             if marker.exists():
                 marker.unlink(missing_ok=True)
+        _restore_live_ledger(ledger_before)

--- a/tests/unit/agents_shared/test_no_live_ledger_write.py
+++ b/tests/unit/agents_shared/test_no_live_ledger_write.py
@@ -1,0 +1,133 @@
+"""Guard: a pytest session must never write the operator's live harness state.
+
+Issue #407. The harness hooks resolve their state directory from
+``HARNESS_STATE_ROOT`` and **default to the real repository root**
+(``.agents/shared/work_ledger.py``, and ten sibling hook modules). Isolation is
+therefore opt-in per call site, and a test that forgets it silently rewrites
+``.agents/state/current-work.json`` — the file the ``SessionStart`` hook reads
+back as session context. In #407 a fixture prompt carrying a ``[trivial]``
+exception token landed there and was read, in a later session, as a
+process-gate waiver nobody issued.
+
+Eight call sites did opt in. Five files did not, by two distinct mechanisms:
+
+* **inherited environment** — ``subprocess.run`` with no ``env=`` hands the
+  child ``os.environ``, so an unset ``HARNESS_STATE_ROOT`` reaches the hook
+  (``test_token_parser.py``, ``test_shared_module_parity.py``,
+  ``test_locale.py``, ``tests/integration/test_stop_hook_e2e.py``);
+* **in-process import** — a hook module exec'd inside pytest via ``importlib``
+  writes through ``work_ledger`` in *this* process (``test_fail_open.py``).
+
+The fix makes isolation the session default (``tests/conftest.py``) rather than
+a per-call-site obligation, because a per-call fix protects the sites that
+exist today and nothing else. These tests pin that default from both ends: the
+environment the session runs under, and the behaviour of a deliberately naive
+subprocess helper.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_LIVE_LEDGER = _REPO_ROOT / ".agents" / "state" / "current-work.json"
+_CODEX_UPS_HOOK = _REPO_ROOT / ".codex" / "hooks" / "user-prompt-submit.py"
+_SHARED_DIR = _REPO_ROOT / ".agents" / "shared"
+
+
+def _live_ledger_fingerprint() -> str | None:
+    """Exact bytes of the live ledger, or ``None`` when it does not exist."""
+    try:
+        return _LIVE_LEDGER.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# The session default itself
+# ---------------------------------------------------------------------------
+
+
+def test_harness_state_root_is_set_and_not_the_repo() -> None:
+    """``tests/conftest.py`` must redirect harness state away from the repo."""
+    raw = os.environ.get("HARNESS_STATE_ROOT")
+    assert raw, (
+        "HARNESS_STATE_ROOT is unset for this pytest session, so every harness "
+        "hook a test spawns writes the real .agents/ and .codex/ state dirs. "
+        "tests/conftest.py is supposed to set it (#407)."
+    )
+    assert Path(raw).resolve() != _REPO_ROOT.resolve(), (
+        f"HARNESS_STATE_ROOT points at the repository itself ({raw}); "
+        "harness state written by tests would be the operator's live state."
+    )
+
+
+def test_in_process_work_ledger_resolves_outside_the_repo() -> None:
+    """The in-process leak path: ``work_ledger`` binds its paths at import.
+
+    ``STATE_ROOT`` is a module-level constant, so a test that exec's a hook
+    inside the pytest process (``test_fail_open.py``) writes wherever
+    ``work_ledger`` resolved on *first* import. Setting the variable in a
+    fixture would be too late; setting it in ``tests/conftest.py`` at module
+    scope is early enough, and this asserts that it was.
+    """
+    if str(_SHARED_DIR) not in sys.path:
+        sys.path.insert(0, str(_SHARED_DIR))
+    import work_ledger  # noqa: PLC0415
+
+    assert work_ledger.LEDGER_PATH.resolve() != _LIVE_LEDGER.resolve(), (
+        "work_ledger resolved to the live ledger "
+        f"({work_ledger.LEDGER_PATH}); an in-process hook exec would overwrite "
+        "the operator's prompt."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behaviour: the naive helper shape must be safe by default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not _CODEX_UPS_HOOK.exists(), reason="Codex UserPromptSubmit hook not present"
+)
+def test_environ_inheriting_hook_subprocess_leaves_live_ledger_untouched() -> None:
+    """Spawn a real hook the way an un-isolated helper does, and prove it.
+
+    This deliberately reproduces the #407 call shape — ``subprocess.run`` with
+    no ``env=``, so the child inherits ``os.environ`` — with a prompt that
+    drives the hook down its ``update_last_prompt`` path. Passing an explicit
+    isolated ``env`` here would test the fix's *workaround* rather than its
+    default, and would stay green if the session default were removed.
+    """
+    before = _live_ledger_fingerprint()
+    marker = "#407 guard prompt — must never reach the live ledger"
+
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, str(_CODEX_UPS_HOOK)],
+        input=json.dumps({"prompt": f"[trivial] {marker}"}),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    after = _live_ledger_fingerprint()
+    if before is None:
+        assert after is None, (
+            "The hook created the live ledger at "
+            f"{_LIVE_LEDGER} during a test run (#407)."
+        )
+    else:
+        assert after == before, (
+            f"The live ledger at {_LIVE_LEDGER} was rewritten by a test-spawned "
+            "hook (#407). HARNESS_STATE_ROOT did not reach the child process."
+        )
+        assert marker not in (after or ""), (
+            "A test fixture prompt is now stored as the operator's last_prompt."
+        )


### PR DESCRIPTION
Closes #407.

## Reported vs observed

The issue is `observed` and reproduced exactly as filed: before `pytest tests/unit/agents_shared/`, `last_prompt` held the operator's real prompt; after, `'[trivial] benign typo fix'`.

Two of its claims did not survive measurement, and both widened the fix.

**The narrow run does reproduce.** The issue records that `-k "trivial or typo"` "does **not** show the mutation". It does — with a *different* fixture, `'［trivial］ fullwidth NFKC'` from `test_shared_module_parity.py:66`. The original conclusion was drawn from looking for one specific string rather than for *a* change.

**Three runners was one file of five.** Rather than read the call sites, I measured them: restore the ledger, run one file, hash. Five files mutate live state, by two mechanisms — and one of them is not in `tests/unit/agents_shared/` at all.

| file | fixture that lands in the ledger | mechanism |
|---|---|---|
| `test_token_parser.py` | `[trivial] benign typo fix` | subprocess, no `env=` |
| `test_shared_module_parity.py` | `［trivial］ fullwidth NFKC` | subprocess, no `env=` |
| `test_locale.py` | *(Stop hook — rewrites `meta` + `verification`)* | subprocess, no `env=` |
| `tests/integration/test_stop_hook_e2e.py` | *(Stop hook)* | `env=` built **from scratch** — inherits nothing |
| `test_fail_open.py` | `[trivial] A-1 stderr check` | **in-process** `importlib` exec of the hook |

The last two are the ones that matter for scope. `test_fail_open.py` loads `.codex/hooks/user-prompt-submit.py` inside the pytest process and calls `main()`; no amount of `env=` on a `subprocess.run` reaches it. And `test_stop_hook_e2e.py` shows the leak was never confined to the directory the issue named.

## Root cause

- **symptom site** — `.agents/state/current-work.json`, read back by SessionStart as session context
- **propagation** — pytest → hook (spawned or exec'd) → `work_ledger.update_last_prompt()` → `LEDGER_PATH`
- **root cause** — `.agents/shared/work_ledger.py:65`, and ten sibling hook modules: `Path(os.environ.get("HARNESS_STATE_ROOT", REPO_ROOT))`. The default is correct for production and makes isolation **opt-in per call site** under test. A site that forgets it does not fail; it succeeds against production state.

That framing is why this PR does not do what the issue proposed. Eight sites had opted in and five files had not; fixing the three runners by name would have left the other four, and could not have fixed `test_fail_open.py` at all.

## Fix

**`tests/conftest.py`** — set `HARNESS_STATE_ROOT` to a session temp dir at **module scope**. Module scope, not a fixture, because `work_ledger.STATE_ROOT` is a module-level constant bound on first import; a fixture runs after collection has already imported it. This covers both mechanisms at once: children inherit `os.environ`, and in-process imports bind to the temp root.

Not `setdefault` — an ambient `HARNESS_STATE_ROOT` pointing at the repo would silently reinstate the bug, and nothing asserts the unset default (`test_work_ledger.py` patches module attributes instead, which is immune to this).

**`tests/integration/test_stop_hook_e2e.py`** — builds a stripped env from scratch and *deliberately* writes the real `.codex/state/` ("so it exercises the actual production lifecycle path"). Redirecting it would defeat the test, so it snapshots and restores the ledger in the `finally` block that already cleans up its markers — extending the contract the file already honours rather than changing its design.

**`tests/unit/agents_shared/test_no_live_ledger_write.py`** — three guards: the session env is set and is not the repo; in-process `work_ledger` resolves outside the repo; and a hook spawned the naive way (`subprocess.run`, no `env=`) leaves the live ledger byte-identical. The third deliberately omits `env=` — passing an isolated env would test the workaround and stay green if the default were removed.

The three runners named in the issue get no per-call `env=`: it would be redundant, and redundancy at the call site is what created the illusion that the problem was bounded.

## Cause Impact Matrix

| candidate | reachability evidence | disposition | evidence |
|---|---|---|---|
| subprocess helpers with no `env=` | 4 files measured mutating; ~20 `subprocess.run` sites in `tests/unit/agents_shared/` inherit `os.environ` | test added | session default + `test_environ_inheriting_hook_subprocess_leaves_live_ledger_untouched` |
| in-process `importlib` hook exec | `test_fail_open.py:259` sets `sys.stdin` and calls `mod.main()` in-process | test added | `test_in_process_work_ledger_resolves_outside_the_repo` |
| `env=` built from scratch (inherits nothing) | 2 hook-launching sites: `test_fail_open.py:86`, `test_stop_hook_e2e.py:70` | test added / not reached | e2e restores the ledger; `test_fail_open.py:86` copies the shim into a fake repo whose `parents[2]` has no `.agents/shared` |
| `env=` derived from `os.environ` | `test_harness_python_launcher.py:20` (`os.environ.copy()` + update), `test_verify_first.py`, `test_stage_gate.py`, `test_plan_execute_gate.py`, `test_antigravity_harness.py`, `test_antigravity_hardening.py`, `test_native_workflow.py` | already covered | inherits the session default; the last six also set `HARNESS_STATE_ROOT` explicitly and are unaffected either way |
| **harness-copy axis** — same hook basename in `.claude/`, `.codex/`, `.antigravity/`, `.agents/` | 11 modules read `HARNESS_STATE_ROOT`; `.antigravity/hooks/_shared.py:12` and `.codex/hooks/stop-sync-reminder.py:55` are separate copies of the same idiom | already covered | one env var governs every copy — the session default is set once and reaches all of them; verified by hashing all four live state dirs across a full run |
| test dirs outside `tests/unit/agents_shared/` | `tests/integration/test_stop_hook_e2e.py` spawns hooks and leaked; `tests/unit/tools/test_pyright_scope.py` measured clean | test added | fix placed in `tests/conftest.py`, which covers all of `tests/` — the reason it is not the package conftest the issue suggested |
| other live state (`.claude/state`, `.codex/state`, `.antigravity/state`) | the same var governs marker dirs, and markers were the subject of the earlier `test_no_test_state_leak.py` guard | already covered | before/after hash of all four dirs over a full `pytest tests/` run: unchanged |

**Termination: closed.** Not by inspection — by measuring every file, then hashing all four live state directories across a full-suite run.

## Prevention

`tests/unit/agents_shared/test_no_test_state_leak.py` already existed to stop exactly this class, and could not see it: it is an **AST** guard matching **string literals** of `.claude/state` / `.codex/state` / `.antigravity/state` inside **fixture bodies**. This leak has no literal (it is an inherited env var), is not in a fixture (module-level helpers), reaches a path not in its list (`.agents/state`), and happens in a child process. A static guard for a dynamic, environmental leak. The new guard is behavioural, which is why it catches it.

## Verification

- guard **red 3/3 before** the fix, each for its own claimed reason
- guard **red 3/3 again** with only the `tests/conftest.py` line reverted — the guard is not vacuous
- removing only the e2e restore brings that leak back — both edits are independently load-bearing
- `uv run pytest tests/ -q` → **2126 passed, 16 skipped**, with a before/after hash of all four live state dirs **unchanged**
- issue reproduction: `last_prompt` identical before and after `pytest tests/unit/agents_shared/`; ditto the narrow `-k` run
- `uv run pyright` → **0 errors** (the 76 seen first were a worktree missing its extras, not this change)
- `uv run pre-commit run --files <changed>` → all pass; `tools/check_language_policy.py` → 0 violations
- `tools/check_governor_footer.py --require-governor-footer` against the changed-file list → 0 violations: no governor path touched, so no footer

## Sync

**Sync Required: true.** No governor path is touched here, so this stays a fix-only PR in the #401→#402→#403 shape. The drift candidate for `/sync-guidelines`: [`docs/ai/shared/test-patterns.md`](docs/ai/shared/test-patterns.md) has a § Harness Hook Tests section (from #401) that should record the new convention — harness state isolation is a **session default**, and a call site building `env` from scratch must handle it itself.
