### PR TITLE
docs: present backend and AI collaboration harness as equal pillars

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,14 @@
 </p>
 
 <p align="center">
-  <b>FastAPI backend blueprint for AI agent applications.</b><br>
-  DDD domains · SQLAlchemy/Alembic · Taskiq workers · admin UI · RAG infrastructure · Claude/Codex collaboration harness.
+  <b>A FastAPI backend blueprint for teams building with AI coding agents.</b><br>
+  A modular backend to run your application. A shared collaboration harness to guide how your team develops it.
 </p>
 
 <p align="center">
-  <a href="#try-it-in-60-seconds">60s Quickstart</a>
-  · <a href="#why-this-blueprint">Why</a>
-  · <a href="#ai-collaboration-harness">AI Collaboration</a>
-  · <a href="#how-it-compares">Comparison</a>
-  · <a href="#architecture-at-a-glance">Architecture</a>
+  <a href="#quickstart">Run the backend</a>
+  · <a href="#ai-collaboration-harness">Explore the harness</a>
+  · <a href="#why-this-blueprint">Is it a fit?</a>
   · <a href="docs/README.ko.md">한국어</a>
 </p>
 
@@ -37,187 +35,150 @@
   </a>
 </p>
 
----
+| Backend foundation | AI collaboration harness |
+|---|---|
+| Domain logic shared by HTTP APIs, background tasks, and an admin UI. Optional AI and infrastructure adapters let you start locally and add services as needed. | Repository rules, task-specific skills, hooks, and review procedures guide changes to that backend across Claude Code, Codex, and Antigravity. |
+| [Run it locally](#quickstart) · [See the architecture](#architecture-at-a-glance) | [Follow an API change](#ai-collaboration-harness) · [Read the shared workflow](docs/ai/shared/target-operating-model.md) |
 
-## Try it in 60 seconds
+## Why this blueprint
 
-No Docker, no PostgreSQL, no cloud credentials — SQLite + in-memory broker.
+Use it when you need multiple business domains, API + worker + admin surfaces,
+or a shared development workflow for teammates using AI coding tools. The
+backend and harness are designed together: the harness references this repo's
+layering, contracts, and verification commands.
+
+Budget time to learn the domain layout, dependency-injector containers, and
+plan/review workflow. A small single-purpose API may not need that structure;
+a project needing a bundled customer frontend needs a different starting point.
+The harness is repository-specific, not a standalone drop-in package.
+
+You can develop without AI tools using the [manual domain tutorial](docs/tutorial/first-domain.md).
+For incremental adoption and trade-offs, see the [adoption guide](docs/adoption.md)
+and [selection guide](docs/comparison.md).
+
+<a id="try-it-in-60-seconds"></a>
+
+## Quickstart
+
+Prerequisites: Python **>=3.12.9**, [uv](https://docs.astral.sh/uv/), Git, and
+`make`. The demos also use `curl` and `python3` on your PATH.
+No Docker, PostgreSQL, cloud credentials, or AI coding tool required.
+
+**Terminal 1 — start the backend:**
 
 ```bash
 git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
 cd fastapi-agent-blueprint
-make setup        # one-time: venv + deps via uv
-make quickstart   # FastAPI on :8001, SQLite schema auto-created
+make quickstart
 ```
 
-In a second terminal, `make demo` exercises the `auth` + `user` domains across
-both token realms (customer register → seed a demo admin → admin login → user
-CRUD → refresh → logout) and `make demo-rag` exercises the
-`docs` domain (end-to-end RAG: upload → chunk → embed → retrieve → answer
-with citations, zero credentials):
+This installs the quickstart dependencies, creates a SQLite database, and keeps
+the server running on port 8001. Use a fresh checkout for evaluation:
+`quickstart` syncs the admin extra and can remove other installed extras.
+For development dependencies and commit hooks, use `make setup` when moving to
+the [development setup](docs/reference.md#local-development-with-postgresql).
 
-```text
-→ Health check
-{ "status": "ok" }
-
-→ Register
-{ "success": true, "data": { "accessToken": "...", "refreshToken": "..." } }
-
-→ Create a user
-{ "success": true, "data": { "id": 2, "username": "bob", ... } }
-
-→ List users (page=1, pageSize=10)
-{ "data": [ { "id": 1, "username": "alice" }, { "id": 2, "username": "bob" } ],
-  "pagination": { "currentPage": 1, "totalItems": 2, "hasNext": false } }
-
-→ Update the user    → Delete the user
-→ Refresh token      → Logout
-→ Done. API docs: http://127.0.0.1:8001/docs
-```
-
-- API docs: <http://127.0.0.1:8001/docs> (Stoplight Elements & Scalar recommended; spec download + frontend handoff link on the same page)
-- Admin UI: <http://127.0.0.1:8001/admin> (`admin` / `admin`)
-- Full walkthrough: [`docs/quickstart.md`](docs/quickstart.md)
-- Frontend handoff: [`docs/frontend-handoff.md`](docs/frontend-handoff.md)
-- Real dev stack (PostgreSQL + migrations): [`docs/reference.md`](docs/reference.md#local-development-with-postgresql)
-
----
-
-## Platform in action
-
-Clone → quickstart → CRUD → JWT auth → background worker → RAG query:
+**Terminal 2 — from the same repository directory:**
 
 ```bash
-make quickstart && make demo && make demo-rag
+make demo       # JWT auth, admin-realm login, user CRUD, refresh and logout
+make demo-rag   # document upload, retrieval and an answer with citations
 ```
 
+Keep terminal 1 running. Both demos check their API responses and report failure
+if a request does not succeed. The default RAG demo uses a keyword-based stub
+embedder and a templated stub answer agent; it demonstrates the pipeline without
+calling an external model.
+
+- [API docs](http://127.0.0.1:8001/docs) — browse the API or download its OpenAPI spec.
+- [Admin UI](http://127.0.0.1:8001/admin) — evaluation bootstrap login: `admin` / `admin`.
+- [Quickstart details](docs/quickstart.md) · [Full integration walkthrough](docs/canonical-demo.md).
+
+These defaults are for local evaluation. Follow the development and deployment
+guides before using real data or exposing the service.
+
+<a id="platform-in-action"></a>
+
 <!-- Regenerate with `make demo-gif` whenever scripts/demo.sh changes. -->
-![API demo: health check → register → JWT → admin realm → user CRUD](docs/assets/cast/demo.gif)
+![Backend demo: authentication and user CRUD](docs/assets/cast/demo.gif)
 
+## Backend foundation
 
-Full integration walkthrough (auth · RBAC · worker · admin · RAG · OTEL): [`docs/canonical-demo.md`](docs/canonical-demo.md)
+| Capability | What it provides |
+|---|---|
+| Domain structure | Router → Service → Repository, with an optional UseCase for orchestration; automatic domain registration and reusable CRUD base classes. |
+| API, worker, admin | FastAPI endpoints, Taskiq background tasks, and NiceGUI admin pages consuming domain services. |
+| Optional infrastructure | SQL databases, DynamoDB, object storage, vector storage, and AI providers behind adapters and configuration. Start with SQLite + InMemory. |
+| Operations | JWT/RBAC, structured logging, opt-in OpenTelemetry, AI usage accounting, and error notifications. |
 
----
+<a id="ai-use-case-document-qa-srcdocs"></a>
 
-## Why this blueprint
+### Worked example: document QA
 
-<table>
-<tr>
-<td width="60%" valign="top">
+The `docs` domain composes document upload, chunking, embedding, retrieval, and
+answers with citations. Its shared RAG pipeline can be reused by other domains
+([ADR 040](docs/history/040-rag-as-reusable-pattern.md)).
 
-**Production rigor**
+For real model calls, install the `pydantic-ai` extra, configure
+`EMBEDDING_PROVIDER` + `EMBEDDING_MODEL` and `LLM_PROVIDER` + `LLM_MODEL`, and
+supply the selected providers' credentials. See the
+[configuration reference](docs/reference.md) for optional extras and settings;
+the [RAG walkthrough](docs/canonical-demo.md) shows the flow.
 
-- **DDD layers (4-tier)** — Interface · Domain · Infrastructure · Application, enforced by pre-commit import guard
-- **Zero-boilerplate CRUD** — 8 async methods via `BaseService` + `BaseRepository`, paginated list with `QueryFilter` included
-- **Auto domain discovery** — drop a folder into `src/{name}/`, it auto-registers. No container edits, no bootstrap edits
-- **Agent backend surfaces** — REST API, async worker, admin UI, and a planned MCP interface over the same domain logic
-- **Pluggable infra** — PostgreSQL / MySQL / SQLite · DynamoDB · S3 / MinIO · S3 Vectors · SQS / RabbitMQ · OpenAI / Bedrock
-- **OpenTelemetry** — `[otel]` extra, `OTEL_ENABLED` env flag, Jaeger/Tempo/Phoenix recipe
-- **Error notifications** — optional Slack/Discord webhook alerts from the exception handlers and from worker task failures, severity + cooldown gated, with optional per-severity channel routing ([runbook](docs/operations/error-notifications.md))
-- **JWT + RBAC** — HS256 auth domain, DB-backed refresh rotation, `User.role` admin gating
-- **AI Usage Ledger** — per-call LLM accounting, `ai_usage` domain, admin + API surfaces
-- **Taskiq smart retry** — task-scoped structured logging, permanent-aware retry policy
-- **Frontend handoff** — OpenAPI download, Bruno/Postman/Hey API/Orval recipes, JWT flow, camelCase contract ([`docs/frontend-handoff.md`](docs/frontend-handoff.md))
+<a id="interfaces"></a>
 
-</td>
-<td width="40%" valign="top">
-
-**AI-assisted acceleration**
-
-- **Claude/Codex collaboration harness** — shared `AGENTS.md`, mirrored skills, and hook-backed workflow reminders
-- `/new-domain order` or `$new-domain order` scaffolds **44 files** (15 source + 25 `__init__.py` + 4 tests) in one command
-- **15 Claude Code + 15 Codex CLI skills** sharing the same architecture and review rules
-- **AI-assisted development (AIDD)** — humans keep product judgment; agents follow repeatable domain, test, review, and drift-check workflows
-- Full setup: [`docs/ai-development.md`](docs/ai-development.md)
-- Manual path: [`docs/tutorial/first-domain.md`](docs/tutorial/first-domain.md) (Path B)
-
-![/new-domain order → 44 files scaffolded → tests pass](docs/assets/cast/new-domain.gif)
-
-> Works as a normal FastAPI blueprint. With Claude Code or Codex CLI, the same production workflow becomes AI-assisted and repeatable.
-
-</td>
-</tr>
-</table>
-
----
+HTTP, worker, and admin interfaces are implemented. The MCP server interface
+is [planned](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18), not
+part of the runnable backend today.
 
 ## AI collaboration harness
 
-Most templates stop at generated files. This blueprint also ships the
-collaboration layer that keeps AI coding agents useful after the first
-scaffold:
+The harness helps contributors work within the same backend conventions:
 
-- **Shared source of truth** — `AGENTS.md` defines the architecture, DTO rules, logging rules, security constraints, and default coding flow.
-- **Claude Code + Codex parity** — tool-specific harnesses point back to the same shared rules instead of drifting into separate playbooks.
-- **Repo-local skills** — domain scaffolding, API work, admin pages, worker tasks, migrations, tests, architecture review, security review, and guideline sync.
-- **Governed changes** — pre-commit checks, import guards, language policy, and review workflows catch architecture drift before it becomes team debt.
+| Capability | What it provides |
+|---|---|
+| Shared rules | `AGENTS.md` and shared references define architecture, contracts, security constraints, and the development workflow. |
+| Task-specific skills | Guides for domains, APIs, worker tasks, admin pages, migrations, testing, review, and documentation sync. |
+| Workflow boundaries | Planning and execution are separate steps. Scope changes, missing verification, and completion checks have explicit handling. |
+| Checks and review | Commit/CI checks inspect deterministic rules; reviews assess behavior, architectural fit, and documentation drift. |
 
-The result is a backend starter that can be used by hand, then accelerated by
-AI tools without asking every contributor to remember the whole architecture
-from scratch.
+### Worked example: add an API to an existing domain
 
----
+For a request such as “add a filtered list endpoint to the order domain,” the
+workflow is:
 
-## How it compares
+| Step | Contributor and agent actions |
+|---|---|
+| Frame and plan | Clarify the contract and affected layers with `/plan-feature` (Claude) or `$plan-feature` (Codex). Review the resulting execution packet. |
+| Start execution | The contributor explicitly invokes `/execute-plan` or `$execute-plan` with that packet. The executor routes API implementation through the `add-api` skill. |
+| Implement and verify | Reuse the existing layer patterns, add relevant tests, and run the packet's verification commands. Surface unplanned capability gaps before expanding the work. |
+| Review and sync | Review the diff; reconcile affected documentation with `sync-guidelines` when needed. Record verification and any unresolved items before PR completion. |
 
-| Feature | FastAPI Agent Blueprint | [tiangolo/full-stack](https://github.com/fastapi/full-stack-fastapi-template) | [s3rius/template](https://github.com/s3rius/FastAPI-template) | [teamhide/boilerplate](https://github.com/teamhide/fastapi-boilerplate) |
-|---|:-:|:-:|:-:|:-:|
-| Zero-boilerplate CRUD (8 methods) | **Yes** | No | No | No |
-| Auto domain discovery | **Yes** | No | No | No |
-| Architecture enforcement (pre-commit) | **Yes** | No | No | No |
-| AI workflow skills (Claude + Codex) | **15 + 15** | 0 | 0 | 0 |
-| Vector infrastructure (S3 Vectors) | **Yes** | No | No | No |
-| Multi-interface (API + Worker + Admin + MCP) | **3 + 1 planned** | 2 | 1 | 1 |
-| Architecture Decision Records | **29 active · 30 archived** | 0 | 0 | 0 |
-| Type-safe generics across layers | **Yes** | Partial | Partial | No |
-| IoC container DI | **Yes** | No | No | No |
+This is an illustrative workflow, not a command that runs every step
+automatically. Human decisions remain part of the process.
 
-Full comparison including Litestar, Robyn, cookiecutter, and adoption paths: [`docs/comparison.md`](docs/comparison.md)
+**What is enforced?** Configured pre-commit/CI checks block detected violations
+such as prohibited imports, broken documentation links, or shared-file language
+policy failures. Workflow reminders are advisory in many cases. For example,
+the plan-to-execution gate blocks matching source edits in Claude, while Codex
+receives a Stop-time advisory. Tool adapters share policy but do not provide
+identical enforcement. See the [operating model](docs/ai/shared/target-operating-model.md)
+for current coverage and exceptions.
 
----
+Domain scaffolding is another supported task:
 
-## AI use case: document QA (`src/docs/`)
+![Domain scaffolding through the new-domain skill](docs/assets/cast/new-domain.gif)
 
-The blueprint ships a worked RAG example — upload documents, ask questions,
-get structured answers with citations. It proves the building blocks
-(vectors, embeddings, LLM agent, worker, admin) compose end-to-end.
-
-```bash
-make quickstart   # terminal 1
-make demo-rag     # terminal 2 — seeds 3 docs, runs a query
-```
-
-```text
-POST /v1/docs/documents   # chunk → embed → upsert
-POST /v1/docs/query       # embed question → top-k retrieval → agent answer
-GET  /admin/docs          # browse + query playground
-```
-
-Under the hood, the RAG orchestration is a **reusable `_core` pattern**
-([ADR 040](docs/history/040-rag-as-reusable-pattern.md)), not a domain.
-`src/docs/` is one consumer; future AI domains (`support_bot`, `product_qa`)
-inject the same `RagPipeline` instead of duplicating chunking + retrieval
-code:
-
-```python
-# src/_core/domain/services/rag_pipeline.py
-class RagPipeline(Generic[TChunk]):
-    async def answer(self, question, top_k=5, filters=None) -> tuple[QueryAnswer, list[TChunk]]:
-        ...  # embed → vector_store.search → answer_agent.answer
-```
-
-Zero-config path uses a **stub embedder** (keyword bag-of-words) and **stub
-answer agent** (templated response from retrieved chunks), both in
-`src/_core/infrastructure/rag/`. Set `EMBEDDING_PROVIDER` + `LLM_PROVIDER`
-in `.env` to swap in real providers — the pipeline is the same.
-
----
+[Set up Claude Code or Codex](docs/ai-development.md) ·
+[Antigravity harness](.antigravity/rules/project-harness.md) ·
+[Shared rules](AGENTS.md) ·
+[Manual development path](docs/tutorial/first-domain.md)
 
 ## Architecture at a glance
 
-Every domain under `src/{domain}/` has four DDD layers. Arrows mean
-**"depends on"**. `Application` (use cases) is optional — the dotted
-line is the common path for simple CRUD (Router → Service directly).
+Every domain separates Interface, Domain, Infrastructure, and optional
+Application code. Runtime CRUD follows Router → Service → Repository;
+dependency arrows below describe imports, not request execution order.
 
 ```mermaid
 flowchart LR
@@ -241,94 +202,39 @@ flowchart LR
     Other["Another domain"] -. via Protocol-based DIP .-> D
 ```
 
-| Layer | Role | Base class |
-|---|---|---|
-| Interface | Router · Request/Response · Admin · Worker task | — |
-| Domain | Service · Protocol · DTO · Exceptions | `BaseService[CreateDTO, UpdateDTO, ReturnDTO]` |
-| Infrastructure | Repository · Model · DI container | `BaseRepository[ReturnDTO]` |
-| Application | UseCase — optional orchestrator | — |
+<a id="data-flow--write-post--put--delete"></a>
+<a id="storage-variants"></a>
 
-> Full set of diagrams (Layer · Write · Read) plus RDB / DynamoDB / S3
-> Vectors variants lives in
-> [`docs/ai/shared/architecture-diagrams.md`](docs/ai/shared/architecture-diagrams.md).
-> Non-Mermaid viewers:
-> [SVG exports](docs/assets/architecture/).
+Request schemas can pass directly to services when fields match. Model-to-DTO
+conversion belongs in repositories. Detailed write/read flows and storage
+variants are in the [architecture guide](docs/ai/shared/architecture-diagrams.md)
+([SVG versions](docs/assets/architecture/)).
 
-### Data flow — Write (`POST` / `PUT` / `DELETE`)
-
-```mermaid
-flowchart LR
-    C[Client] -->|"HTTP + JSON"| R[Router]
-    R -->|"Request schema"| S[Service]
-    S -->|"entity"| Re["Repository<br/>BaseRepository[DTO]"]
-    Re -->|"Model(**dto.model_dump())"| M[ORM Model]
-    M -->|"SQLAlchemy"| DB[(Database)]
-```
-
-- **Request → Service** directly when fields match (no intermediate DTO — [ADR 004](docs/history/004-dto-entity-responsibility.md)).
-- **Model ↔ DTO** conversion happens *only* inside the Repository.
-- Read flow is the mirror image; the Router strips sensitive fields on the way out.
-
-### Storage variants
-
-Same flow, different base classes:
-
-| Storage | Service base | Repository / Store base | List return |
-|---|---|---|---|
-| RDB (default) | `BaseService[Create, Update, DTO]` | `BaseRepository[DTO]` | `(list[DTO], PaginationInfo)` |
-| DynamoDB | `BaseDynamoService[…]` | `BaseDynamoRepository[DTO]` | `CursorPage[DTO]` |
-| S3 Vectors | domain-specific | `BaseS3VectorStore[DTO]` | `VectorSearchResult[DTO]` |
-
----
-
-## Interfaces
-
-One business logic, multiple surfaces:
-
-| Interface | Tech | Status | Purpose |
-|---|---|---|---|
-| HTTP API | FastAPI | Stable | REST endpoints |
-| Async worker | Taskiq + SQS / RabbitMQ / InMemory | Stable | Background jobs |
-| Admin UI | NiceGUI | Stable | Auto-generated admin CRUD |
-| MCP server | FastMCP | Planned ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18)) | AI agent tool interface |
-
----
+<a id="how-it-compares"></a>
 
 ## Learn more
 
-| I want to… | Read |
+| Backend development | AI collaboration |
 |---|---|
-| Spin it up and poke around | [`docs/quickstart.md`](docs/quickstart.md) |
-| See everything work end-to-end (auth · RBAC · worker · RAG · OTEL) | [`docs/canonical-demo.md`](docs/canonical-demo.md) |
-| Build a real domain, end-to-end | [`docs/tutorial/first-domain.md`](docs/tutorial/first-domain.md) |
-| See small, pattern-focused example apps | [`examples/`](examples/) |
-| Understand the architecture in depth | [`docs/ai/shared/architecture-diagrams.md`](docs/ai/shared/architecture-diagrams.md) · [`AGENTS.md`](AGENTS.md) |
-| Set up Claude Code or Codex CLI | [`docs/ai-development.md`](docs/ai-development.md) |
-| Add a domain by hand (no AI tools) | [`docs/tutorial/first-domain.md`](docs/tutorial/first-domain.md) (Path B) |
-| Adopt into an existing FastAPI project | [`docs/adoption.md`](docs/adoption.md) |
-| Check Python / FastAPI / tool version support | [`docs/compatibility.md`](docs/compatibility.md) |
-| See detailed env vars, tech stack, project tree | [`docs/reference.md`](docs/reference.md) |
-| Understand why a decision was made | [ADR index](docs/history/README.md) (29 active · 30 archived) |
-| Follow what's next | [Roadmap](docs/reference.md#roadmap) · [issue tracker](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues) |
-
----
+| [Quickstart](docs/quickstart.md) · [Integration walkthrough](docs/canonical-demo.md) | [Tool setup](docs/ai-development.md) · [Antigravity](.antigravity/rules/project-harness.md) |
+| [First domain tutorial](docs/tutorial/first-domain.md) · [Examples](examples/) | [Shared rules](AGENTS.md) · [Workflow and exceptions](docs/ai/shared/target-operating-model.md) |
+| [Adoption paths](docs/adoption.md) · [Selection trade-offs](docs/comparison.md) | [Design decisions](docs/history/README.md) |
+| [Configuration](docs/reference.md) · [Compatibility](docs/compatibility.md) · [Frontend handoff](docs/frontend-handoff.md) | [Contribution and review workflow](CONTRIBUTING.md) |
 
 ## Roadmap
 
-- **MCP server interface** — expose domain services as agent tools via FastMCP ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18))
-- **pgvector** — additional vector backend alongside S3 Vectors ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
+- [MCP server interface](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18).
+- [pgvector backend](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11).
 
-See [full roadmap](docs/reference.md#roadmap) · [open issues](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues)
-
----
+See the [full roadmap](docs/reference.md#roadmap) and
+[issue tracker](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues).
 
 ## Contributing
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for dev setup, coding guidelines,
-and the PR workflow. Newcomers — check the
-[`good first issue`](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
-label; the small apps tracked under [`examples/`](examples/) are a
-low-friction place to land your first PR.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and the PR workflow.
+The [examples](examples/) and
+[good first issues](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
+are entry points for new contributors.
 
 ## License
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -18,16 +18,14 @@
 </p>
 
 <p align="center">
-  <b>AI 에이전트 백엔드를 위한 프로덕션 지향 FastAPI 블루프린트.</b><br>
-  DDD 레이어 · 보일러플레이트 제로 CRUD · 도메인 자동 발견 · 멀티 인터페이스 (API · Worker · Admin · MCP 준비) ·<br>
-  벡터 / 임베딩 / LLM 인프라 · Claude Code &amp; Codex CLI용 AI 개발 스킬 내장.
+  <b>팀이 AI 코딩 에이전트와 함께 개발하는 FastAPI 백엔드 블루프린트.</b><br>
+  애플리케이션을 실행할 모듈형 백엔드와, 팀의 개발 과정을 안내하는 공통 협업 하네스를 제공합니다.
 </p>
 
 <p align="center">
-  <a href="#60초-만에-실행">60초 만에 실행</a>
-  · <a href="#한눈에-보는-아키텍처">아키텍처</a>
-  · <a href="#ai-네이티브-개발">AI 스킬</a>
-  · <a href="#비교">비교</a>
+  <a href="#빠르게-실행하기">백엔드 실행하기</a>
+  · <a href="#ai-협업-하네스">하네스 살펴보기</a>
+  · <a href="#왜-이-블루프린트인가">나에게 적합한가?</a>
   · <a href="../README.md">English</a>
 </p>
 
@@ -37,78 +35,142 @@
   </a>
 </p>
 
----
+| 백엔드 기반 | AI 협업 하네스 |
+|---|---|
+| HTTP API·백그라운드 작업·관리자 화면이 도메인 로직을 공유합니다. AI와 외부 인프라는 선택적으로 연결하므로 로컬에서 시작해 필요한 서비스를 추가할 수 있습니다. | 저장소 규칙·작업별 스킬·훅·리뷰 절차가 Claude Code·Codex·Antigravity에서 이 백엔드를 변경하는 과정을 안내합니다. |
+| [로컬 실행](#빠르게-실행하기) · [아키텍처](#한눈에-보는-아키텍처) | [API 변경 사례](#ai-협업-하네스) · [공유 워크플로](ai/shared/target-operating-model.md) |
 
-## 60초 만에 실행
+## 왜 이 블루프린트인가
 
-Docker · PostgreSQL · 클라우드 자격 증명 모두 불필요 — SQLite + In-Memory 브로커.
+여러 비즈니스 도메인, API·워커·관리자 화면, 또는 AI 코딩 도구를 함께 쓰는
+팀의 공통 개발 절차가 필요할 때 적합합니다. 백엔드와 하네스는 함께 설계됐으며,
+하네스는 이 저장소의 계층 구조·계약·검증 명령을 참조합니다.
+
+도메인 구조, dependency-injector 컨테이너, 계획·리뷰 절차를 익힐 시간이 필요합니다.
+작은 단일 목적 API에는 이 구조가 과할 수 있고, 고객용 프런트엔드까지 포함된
+스타터를 원한다면 다른 출발점이 필요합니다. 하네스는 이 저장소에 맞춰져 있으며
+별도로 가져다 쓰는 범용 패키지는 아닙니다.
+
+AI 도구 없이도 [수동 도메인 작성 튜토리얼](tutorial/first-domain.md)로 개발할 수 있습니다.
+점진적 도입과 비용은 [도입 가이드](adoption.md)와 [선택 가이드](comparison.md)를 참고하세요.
+
+<a id="60초-만에-실행"></a>
+
+## 빠르게 실행하기
+
+Python **>=3.12.9**, [uv](https://docs.astral.sh/uv/), Git, `make`가 필요합니다.
+데모는 PATH에 있는 `curl`과 `python3`도 사용합니다.
+Docker·PostgreSQL·클라우드 자격 증명·AI 코딩 도구는 필요하지 않습니다.
+
+**터미널 1 — 백엔드 실행:**
 
 ```bash
 git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
 cd fastapi-agent-blueprint
-make setup        # 최초 1회: uv 로 venv + 의존성 설치
-make quickstart   # :8001 에 FastAPI 기동, SQLite 스키마 자동 생성
+make quickstart
 ```
 
-다른 터미널에서 `make demo` 로 `user` 도메인을 `curl` 로 왕복해봅니다:
+체험용 의존성을 설치하고 SQLite DB를 만든 뒤 8001 포트에서 서버를 계속 실행합니다.
+체험은 새 체크아웃에서 시작하세요. `quickstart`는 admin extra를 동기화하면서 기존에
+설치한 다른 extra를 제거할 수 있습니다. [개발 환경](reference.md#local-development-with-postgresql)으로
+전환할 때 `make setup`으로 개발 의존성과 커밋 훅을 설치합니다.
 
-```text
-→ Health check
-{ "status": "ok" }
+**터미널 2 — 같은 저장소 디렉터리에서 실행:**
 
-→ Create a user
-{ "success": true, "data": { "id": 1, "username": "alice",
-                             "fullName": "Alice Liddell", ... } }
-
-→ List users (page=1, pageSize=10)
-{ "data": [ { "id": 1, "username": "alice", ... } ],
-  "pagination": { "currentPage": 1, "totalItems": 1,
-                  "hasNext": false, ... } }
-
-→ Update the user    → Delete the user
-→ Done. API docs: http://127.0.0.1:8001/docs
+```bash
+make demo       # JWT 인증, 관리자 realm 로그인, 사용자 CRUD, 갱신과 로그아웃
+make demo-rag   # 문서 업로드, 검색, 출처를 포함한 답변
 ```
 
-- API 문서: <http://127.0.0.1:8001/docs> (Stoplight Elements / Scalar 추천; 같은 페이지에 spec download + 프론트엔드 핸드오프 링크)
-- Admin UI: <http://127.0.0.1:8001/admin> (`admin` / `admin`)
-- 전체 안내: [`docs/quickstart.md`](quickstart.md)
-- 프론트엔드 핸드오프: [`docs/frontend-handoff.md`](frontend-handoff.md)
-- 실제 개발 환경 (PostgreSQL + 마이그레이션): [`docs/reference.md`](reference.md#local-development-with-postgresql)
+터미널 1의 서버는 계속 켜 둡니다. 두 데모는 API 응답을 검사하고 요청이 성공하지
+않으면 실패를 보고합니다. 기본 RAG 데모는 키워드 기반 stub 임베더와 템플릿형 stub
+답변 에이전트를 사용하므로 외부 모델을 호출하지 않고 파이프라인을 확인할 수 있습니다.
 
----
+- [API 문서](http://127.0.0.1:8001/docs) — API 탐색과 OpenAPI 명세 다운로드.
+- [관리자 UI](http://127.0.0.1:8001/admin) — 체험용 초기 로그인: `admin` / `admin`.
+- [Quickstart 상세](quickstart.md) · [전체 통합 시연](canonical-demo.md).
 
-## 왜 이 블루프린트인가
+이 기본값은 로컬 체험용입니다. 실제 데이터를 다루거나 서비스를 외부에 공개하기
+전에는 개발·배포 가이드를 따라 설정해야 합니다.
 
-- **도메인 로직을 한 번만 쓰고, 어디서든 노출.** HTTP (FastAPI) + Worker (Taskiq) + Admin (NiceGUI) 가 하나의 Domain 레이어를 공유합니다. MCP 서버는 로드맵에 있음.
-- **보일러플레이트 제로 CRUD.** `BaseRepository[DTO]` 와 `BaseService[Create, Update, DTO]` 를 상속하면 `QueryFilter` 기반 페이징 목록을 포함한 8개 async 메서드를 즉시 확보.
-- **도메인 자동 발견.** `src/{name}/` 에 폴더 하나만 두면 자동 등록. Container 수정도, bootstrap 수정도 필요 없음.
-- **환경변수 한 줄로 교체 가능한 인프라.** PostgreSQL / MySQL / SQLite · DynamoDB · S3 / MinIO · S3 Vectors · SQS / RabbitMQ / InMemory · LLM/Embedding 모두 OpenAI / Bedrock.
-- **커밋 시점에 아키텍처 강제.** Pre-commit 훅이 `Domain → Infrastructure` import 를 차단하여 DDD 계약이 썩지 않도록 보장.
-- **AI 네이티브 워크플로우.** Claude Code 15개 + Codex CLI 15개 스킬이 동일한 `AGENTS.md` 규칙을 공유 — 한 줄로 도메인 스캐폴딩, 라우트 추가, 아키텍처 감사가 가능.
+![백엔드 데모: 인증과 사용자 CRUD](assets/cast/demo.gif)
 
----
+## 백엔드 기반
 
-## 비교
+| 기능 | 제공하는 것 |
+|---|---|
+| 도메인 구조 | Router → Service → Repository와 조합 로직을 위한 선택적 UseCase. 도메인 자동 등록과 재사용 가능한 CRUD 기반 클래스. |
+| API·워커·관리자 | 도메인 서비스를 사용하는 FastAPI 엔드포인트, Taskiq 작업, NiceGUI 관리자 페이지. |
+| 선택적 인프라 | 어댑터와 설정으로 연결하는 SQL DB·DynamoDB·객체 저장소·벡터 저장소·AI 공급자. SQLite + InMemory로 시작 가능. |
+| 운영 | JWT/RBAC, 구조화 로그, 선택적 OpenTelemetry, AI 사용량 기록, 오류 알림. |
 
-| 기능 | FastAPI Agent Blueprint | [tiangolo/full-stack](https://github.com/fastapi/full-stack-fastapi-template) | [s3rius/template](https://github.com/s3rius/FastAPI-template) | [teamhide/boilerplate](https://github.com/teamhide/fastapi-boilerplate) |
-|---|:-:|:-:|:-:|:-:|
-| 보일러플레이트 제로 CRUD (8개 메서드) | **Yes** | No | No | No |
-| 도메인 자동 발견 | **Yes** | No | No | No |
-| 아키텍처 자동 강제 (pre-commit) | **Yes** | No | No | No |
-| AI 워크플로우 스킬 (Claude + Codex) | **15 + 15** | 0 | 0 | 0 |
-| 벡터 인프라 (S3 Vectors) | **Yes** | No | No | No |
-| 멀티 인터페이스 (API + Worker + Admin + MCP) | **3 + 1 예정** | 2 | 1 | 1 |
-| Architecture Decision Records | **29 active · 30 archived** | 0 | 0 | 0 |
-| 전 계층 타입 안전 제네릭 | **Yes** | 부분 | 부분 | No |
-| IoC Container DI | **Yes** | No | No | No |
+### 실제 사례: 문서 질의응답
 
----
+`docs` 도메인은 문서 업로드·청킹·임베딩·검색·출처가 있는 답변을 연결합니다.
+공유 RAG 파이프라인은 다른 도메인에서도 재사용할 수 있습니다
+([ADR 040](history/040-rag-as-reusable-pattern.md)).
+
+실제 모델을 호출하려면 `pydantic-ai` extra를 설치하고,
+`EMBEDDING_PROVIDER` + `EMBEDDING_MODEL`, `LLM_PROVIDER` + `LLM_MODEL`,
+선택한 공급자의 자격 증명을 설정합니다.
+선택적 extra와 설정은 [설정 레퍼런스](reference.md), 전체 흐름은
+[RAG 시연](canonical-demo.md)을 참고하세요.
+
+<a id="인터페이스"></a>
+
+HTTP·워커·관리자 인터페이스는 구현돼 있습니다. MCP 서버 인터페이스는
+[예정 기능](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18)이며
+현재 실행 가능한 백엔드에는 포함되지 않습니다.
+
+<a id="ai-네이티브-개발"></a>
+
+## AI 협업 하네스
+
+하네스는 기여자가 같은 백엔드 규칙에 따라 작업하도록 돕습니다.
+
+| 기능 | 제공하는 것 |
+|---|---|
+| 공통 규칙 | `AGENTS.md`와 공유 레퍼런스에 정의된 아키텍처·계약·보안 제약·개발 절차. |
+| 작업별 스킬 | 도메인·API·워커·관리자 페이지·마이그레이션·테스트·리뷰·문서 동기화 가이드. |
+| 작업 단계 구분 | 계획과 실행을 분리하고, 범위 변경·검증 누락·완료 확인을 명시적으로 다루는 절차. |
+| 검사와 리뷰 | 확정적으로 판별 가능한 규칙을 검사하는 커밋/CI 검사와, 동작·아키텍처 적합성·문서 불일치를 살피는 리뷰. |
+
+### 실제 작업 흐름: 기존 도메인에 API 추가
+
+“order 도메인에 필터링 가능한 목록 API를 추가한다”는 요청을 예로 들면 다음과 같습니다.
+
+| 단계 | 기여자와 에이전트가 하는 일 |
+|---|---|
+| 문제 정의와 계획 | `/plan-feature`(Claude) 또는 `$plan-feature`(Codex)로 계약과 영향받는 계층을 구체화하고 실행 계획을 검토합니다. |
+| 실행 시작 | 기여자가 계획을 지정해 `/execute-plan` 또는 `$execute-plan`을 명시적으로 호출합니다. 실행기는 API 구현을 `add-api` 스킬로 연결합니다. |
+| 구현과 검증 | 기존 계층 패턴을 활용하고 관련 테스트를 추가한 뒤 계획의 검증 명령을 실행합니다. 계획에 없던 기능이 필요하면 작업 범위를 넓히기 전에 알립니다. |
+| 리뷰와 동기화 | 변경을 리뷰하고, 필요한 경우 `sync-guidelines`로 관련 문서를 맞춥니다. 검증 결과와 미해결 사항을 기록한 뒤 PR 완료를 판단합니다. |
+
+이 표는 작업 흐름 예시이며 모든 단계를 자동 실행하는 명령이 아닙니다.
+사람의 판단은 과정에 계속 포함됩니다.
+
+**무엇을 강제하나요?** 설정된 pre-commit/CI 검사는 금지된 import, 깨진 문서 링크,
+공유 파일의 언어 정책 위반 등을 발견하면 차단합니다. 작업 절차 안내는 권고인 경우가
+많습니다. 예를 들어 계획→실행 게이트는 Claude에서 조건에 맞는 소스 편집을 차단하지만,
+Codex에서는 Stop 시점에 안내합니다. 도구별 어댑터는 정책을 공유하지만 강제 수준은
+동일하지 않습니다. 현재 적용 범위와 예외는 [운영 모델](ai/shared/target-operating-model.md)을 참고하세요.
+
+<a id="10분-안에-첫-도메인-만들기"></a>
+
+도메인 스캐폴딩도 지원하는 작업 중 하나입니다.
+
+![new-domain 스킬을 통한 도메인 스캐폴딩](assets/cast/new-domain.gif)
+
+[Claude Code·Codex 설정](ai-development.md) ·
+[Antigravity 하네스](../.antigravity/rules/project-harness.md) ·
+[공통 규칙](../AGENTS.md) ·
+[수동 개발 경로](tutorial/first-domain.md)
 
 ## 한눈에 보는 아키텍처
 
-`src/{domain}/` 아래의 모든 도메인은 4개의 DDD 레이어를 가집니다. 화살표는
-**"의존한다"** 방향. `Application` (use case) 은 선택 사항이며, 단순 CRUD 는
-점선 경로 (Router → Service 직접 연결) 를 사용합니다.
+도메인은 Interface·Domain·Infrastructure와 선택적 Application으로 나뉩니다.
+일반 CRUD의 실행 흐름은 Router → Service → Repository입니다.
+아래 화살표는 요청 처리 순서가 아닌 코드의 의존 방향을 나타냅니다.
 
 ```mermaid
 flowchart LR
@@ -129,132 +191,46 @@ flowchart LR
     D --> Core
     Inf --> Core
 
-    Other["다른 도메인"] -. Protocol 기반 DIP .-> D
+    Other["Another domain"] -. via Protocol-based DIP .-> D
 ```
 
-| 계층 | 역할 | Base 클래스 |
-|---|---|---|
-| Interface | Router · Request/Response · Admin · Worker task | — |
-| Domain | Service · Protocol · DTO · Exceptions | `BaseService[CreateDTO, UpdateDTO, ReturnDTO]` |
-| Infrastructure | Repository · Model · DI container | `BaseRepository[ReturnDTO]` |
-| Application | UseCase — 선택적 오케스트레이터 | — |
+<a id="데이터-흐름--write-post--put--delete"></a>
+<a id="저장소-변종"></a>
 
-> Layer · Write · Read 다이어그램 전체와 RDB / DynamoDB / S3 Vectors
-> 변종 표는
-> [`docs/ai/shared/architecture-diagrams.md`](ai/shared/architecture-diagrams.md)
-> 에 있습니다. Mermaid 가 렌더되지 않는 뷰어용 SVG export:
-> [`docs/assets/architecture/`](assets/architecture/).
+필드가 같으면 Request 스키마를 Service에 직접 전달합니다. Model과 DTO의 변환은
+Repository가 담당합니다. 상세 읽기·쓰기 흐름과 저장소별 구조는
+[아키텍처 가이드](ai/shared/architecture-diagrams.md)
+([SVG 버전](assets/architecture/))에 있습니다.
 
-### 데이터 흐름 — Write (`POST` / `PUT` / `DELETE`)
-
-```mermaid
-flowchart LR
-    C[Client] -->|"HTTP + JSON"| R[Router]
-    R -->|"Request schema"| S[Service]
-    S -->|"entity"| Re["Repository<br/>BaseRepository[DTO]"]
-    Re -->|"Model(**dto.model_dump())"| M[ORM Model]
-    M -->|"SQLAlchemy"| DB[(Database)]
-```
-
-- 필드가 일치하면 **Request 를 Service 로 그대로 전달** — 중간 DTO 불필요 ([ADR 004](history/004-dto-entity-responsibility.md))
-- **Model ↔ DTO 변환은 Repository 안에서만** 발생
-- Read 흐름은 대칭이며, 민감 필드는 Router 가 응답으로 내보내기 직전에 제거
-
-### 저장소 변종
-
-흐름 형태는 동일하고 Base 클래스와 영속 객체만 바뀝니다.
-
-| 저장소 | Service base | Repository / Store base | 리스트 반환 |
-|---|---|---|---|
-| RDB (기본) | `BaseService[Create, Update, DTO]` | `BaseRepository[DTO]` | `(list[DTO], PaginationInfo)` |
-| DynamoDB | `BaseDynamoService[…]` | `BaseDynamoRepository[DTO]` | `CursorPage[DTO]` |
-| S3 Vectors | 도메인별 구현 | `BaseS3VectorStore[DTO]` | `VectorSearchResult[DTO]` |
-
----
-
-## 인터페이스
-
-하나의 비즈니스 로직을 여러 표면으로 노출:
-
-| 인터페이스 | 기술 | 상태 | 용도 |
-|---|---|---|---|
-| HTTP API | FastAPI | Stable | REST 엔드포인트 |
-| 비동기 Worker | Taskiq + SQS / RabbitMQ / InMemory | Stable | 백그라운드 작업 |
-| Admin UI | NiceGUI | Stable | 자동 생성 admin CRUD |
-| MCP server | FastMCP | Planned ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18)) | AI 에이전트 도구 인터페이스 |
-
----
-
-## AI 네이티브 개발
-
-**Claude Code** 와 **OpenAI Codex CLI** 둘 다 일급 지원. 하나의 규칙
-파일 ([`AGENTS.md`](../AGENTS.md)) 과 하나의 workflow 레퍼런스 레이어
-([`docs/ai/shared/`](ai/shared/)) 를 공유하고, 도구별 하네스가 그 위에
-얹힙니다.
-
-| | Claude Code | Codex CLI |
-|---|---|---|
-| 스킬 | 14개 slash 커맨드 (`.claude/skills/`) | 15개 workflow 스킬 (`.agents/skills/`) |
-| 설정 | `CLAUDE.md` + `.mcp.json` | `.codex/config.toml` + `.codex/hooks.json` |
-| 훅 | PostToolUse 자동 포맷 | 6개 훅 (format · security · session-start · …) |
-
-### 10분 안에 첫 도메인 만들기
-
-```text
-/onboard            # 수준별 적응형 온보딩 (초급 ~ 고급)
-/new-domain product # 15개 소스 파일 + 25개 __init__.py + 4개 테스트 생성
-/add-api "add GET /product/top-selling to product"
-/review-architecture product
-```
-
-Codex CLI 를 쓴다면 `/` 대신 `$`. 하네스 없이 손으로 만들고 싶다면
-[**"10분 안에 첫 도메인" 튜토리얼**](tutorial/first-domain.md) 이 두 경로를
-나란히 보여줍니다 — 스킬 한 줄 vs. Python 파일 9개 — 마지막엔 `pytest`
-통과 + 실제 서버에 `curl` 까지 완주.
-
-두 도구에서 모두 동작하는 주요 스킬: `onboard`, `new-domain`, `add-api`,
-`add-worker-task`, `add-admin-page`, `review-architecture`,
-`security-review`, `review-pr`, `plan-feature`, `fix-bug`. 전체 표와
-설치 가이드: [`docs/ai-development.ko.md`](ai-development.ko.md).
-
----
+<a id="비교"></a>
 
 ## 더 읽을거리
 
-| 원하는 것 | 읽을 곳 |
+| 백엔드 개발 | AI 협업 |
 |---|---|
-| 일단 띄워보기 | [`docs/quickstart.md`](quickstart.md) |
-| 도메인 하나 end-to-end 로 만들기 | [`docs/tutorial/first-domain.md`](tutorial/first-domain.md) |
-| 작은 패턴 중심 예제 앱 둘러보기 | [`examples/`](../examples/) |
-| 아키텍처를 깊이 이해 | [`docs/ai/shared/architecture-diagrams.md`](ai/shared/architecture-diagrams.md) · [`AGENTS.md`](../AGENTS.md) |
-| Claude Code / Codex CLI 설정 | [`docs/ai-development.ko.md`](ai-development.ko.md) |
-| 도메인을 수동으로 추가 (AI 도구 없이) | [`docs/tutorial/first-domain.md`](tutorial/first-domain.md) (Path B) |
-| 상세 env 변수 · 기술 스택 · 프로젝트 트리 | [`docs/reference.md`](reference.md) |
-| 어떤 결정을 왜 했는지 | [ADR 인덱스](history/README.md) (29 active · 30 archived) |
-| 다음 계획 | [Roadmap](reference.md#roadmap) · [이슈 트래커](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues) |
-
----
+| [Quickstart](quickstart.md) · [통합 시연](canonical-demo.md) | [도구 설정](ai-development.md) · [Antigravity](../.antigravity/rules/project-harness.md) |
+| [첫 도메인 튜토리얼](tutorial/first-domain.md) · [예제](../examples/) | [공통 규칙](../AGENTS.md) · [워크플로와 예외](ai/shared/target-operating-model.md) |
+| [도입 방법](adoption.md) · [선택 기준](comparison.md) | [설계 결정](history/README.md) |
+| [설정](reference.md) · [호환성](compatibility.md) · [프런트엔드 협업](frontend-handoff.md) | [기여·리뷰 절차](../CONTRIBUTING.md) |
 
 ## 로드맵
 
-- **MCP 서버 인터페이스** — FastMCP 로 도메인 서비스를 에이전트 도구로 노출 ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18))
-- **pgvector** — S3 Vectors 와 병행할 추가 벡터 백엔드 ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
+- [MCP 서버 인터페이스](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18).
+- [pgvector 백엔드](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11).
 
-전체 로드맵: [docs/reference.md#roadmap](reference.md#roadmap) · [이슈 트래커](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues)
-
----
+[전체 로드맵](reference.md#roadmap)과
+[이슈 목록](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues)을 참고하세요.
 
 ## Contributing
 
-개발 환경 설정, 코딩 가이드라인, PR 워크플로우는
-[`CONTRIBUTING.md`](../CONTRIBUTING.md) 를 참고하세요. 새로 오신 분은
-[`good first issue`](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
-라벨을 먼저 확인해주세요. [`examples/`](../examples/) 아래 작은 예제
-앱들이 첫 PR을 내기 좋은 저마찰 진입점입니다.
+개발 환경과 PR 절차는 [CONTRIBUTING.md](../CONTRIBUTING.md)를 참고하세요.
+[예제](../examples/)와
+[good first issue](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues?q=is%3Aopen+label%3A%22good+first+issue%22)에서
+첫 기여를 시작할 수 있습니다.
 
 ## License
 
-[MIT](../LICENSE) — 상업적 사용, 수정, 재배포 자유.
+[MIT](../LICENSE) — 상업적 사용·수정·배포가 가능합니다.
 
 ---
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -12,13 +12,20 @@ Use the GitHub template button to start a fresh project with the full structure:
 2. Clone your new repository and run:
 
 ```bash
-make setup
 make quickstart   # verify it boots
 ```
 
-3. Follow the [10-minute domain tutorial](tutorial/first-domain.md) to add your first domain.
+3. From another terminal in the same directory, run `make demo` and `make demo-rag`.
+   The RAG demo uses deterministic stubs; it does not call an external model.
+4. After evaluation, stop the server and run `make setup` to install development
+   dependencies and commit hooks. Follow the [first-domain tutorial](tutorial/first-domain.md)
+   or [PostgreSQL development setup](reference.md#local-development-with-postgresql).
 
-Everything is pre-wired: DI container, auto-discovery, pre-commit hooks, Claude Code and Codex CLI skills.
+DI, domain discovery, and repository-local skills are supplied by the template.
+Commit hooks are installed by `make setup`; AI tools have their own
+[setup steps](ai-development.md). `make quickstart` is an evaluation command:
+it syncs only the admin extra and may remove other installed extras. Restore
+development dependencies with `make setup` after returning from evaluation.
 
 ---
 

--- a/docs/canonical-demo.md
+++ b/docs/canonical-demo.md
@@ -1,17 +1,20 @@
 # Canonical Demo Walkthrough
 
-This walkthrough runs the complete platform in a single session: JWT auth,
-RBAC-gated admin, background worker, RAG query, and OTEL traces.
-All steps work against SQLite + InMemory broker — no external infra needed.
+Start with JWT auth, RBAC-gated admin, and a stub RAG query on SQLite + InMemory,
+without external infrastructure. Later sections explain the in-process task path
+and optional standalone workers and OTEL traces, which require extra dependencies
+and services.
 
 ---
 
 ## Prerequisites
 
+Python >=3.12.9, [uv](https://docs.astral.sh/uv/), Git, `make`, `curl`, and
+`python3` on your PATH. Start in a fresh evaluation checkout.
+
 ```bash
 git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
 cd fastapi-agent-blueprint
-make setup   # one-time: venv + deps via uv
 ```
 
 ---
@@ -23,6 +26,9 @@ make quickstart
 ```
 
 Expected: server on `http://127.0.0.1:8001`, SQLite schema auto-created.
+`make quickstart` installs its dependencies and keeps this terminal occupied.
+It syncs the admin extra and can remove other extras; reserve `make setup` for
+the development/test step below.
 
 ```text
 INFO  event="server_start" host="127.0.0.1" port=8001 env="quickstart"
@@ -32,13 +38,15 @@ INFO  event="server_start" host="127.0.0.1" port=8001 env="quickstart"
 
 ## Step 2 — CRUD + JWT auth
 
-In a second terminal:
+Keep the server running. In a second terminal, from the same repository directory:
 
 ```bash
 make demo
 ```
 
-This exercises the `auth` and `user` domains end-to-end — register, JWT token issuance, authenticated CRUD, token refresh, and logout:
+This exercises the `auth` and `user` domains end-to-end — customer registration,
+demo-admin seeding and admin-realm login, user CRUD, token refresh, and logout.
+The customer token alone cannot authorize user CRUD.
 
 ```text
 → Health check
@@ -47,7 +55,8 @@ This exercises the `auth` and `user` domains end-to-end — register, JWT token 
 → Register (creates user account + returns JWT token pair)
 { "success": true, "data": { "accessToken": "...", "refreshToken": "..." } }
 
-→ Create a second user (JWT-authenticated)
+→ Seed a demo admin → Admin-realm login
+→ Create a second user (admin JWT-authenticated)
 { "success": true, "data": { "id": 2, "username": "bob", ... } }
 
 → List users (page=1, pageSize=10)
@@ -63,11 +72,15 @@ This exercises the `auth` and `user` domains end-to-end — register, JWT token 
 
 ## Step 3 — RAG pipeline
 
+In the second terminal, with the server still running:
+
 ```bash
 make demo-rag
 ```
 
 Seeds 3 documents, runs a retrieval query, and shows structured citations:
+the default keyword embedder and templated answer agent are deterministic stubs,
+so this step does not evaluate a real model's answer quality.
 
 ```text
 → Upload 3 documents (chunk → embed → upsert)
@@ -108,37 +121,49 @@ full recipe):
 ```bash
 docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management
 # _env/quickstart.env → BROKER_TYPE=rabbitmq, RABBITMQ_URL=amqp://guest:guest@localhost:5672/
+uv sync --extra admin --extra rabbitmq
 uv run python run_server_local.py --env quickstart   # terminal 1
 uv run python run_worker_local.py --env quickstart    # terminal 2 — the standalone worker
 ```
 
 The `user` domain registers a `user.test` task as a reference example — see [`src/user/interface/worker/tasks/user_test_task.py`](../src/user/interface/worker/tasks/user_test_task.py). Replace it with domain-specific background work (email dispatch, async enrichment, scheduled jobs) following the same Taskiq pattern.
 
+Stop the prior server before restarting. Include all extras you need in each
+`uv sync` command. If returning to the no-broker demo, stop your worker and restore
+`BROKER_TYPE=inmemory` before restarting the server.
+
 ---
 
 ## Step 6 — OpenTelemetry traces (optional)
 
-If you have a local Jaeger or Tempo instance:
+With a local Jaeger or Tempo instance, stop the current server, then run:
 
 ```bash
+uv sync --extra admin --extra otel
 OTEL_ENABLED=true \
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
-make quickstart
+uv run python run_server_local.py --env quickstart
 ```
 
 Traces are emitted per-request and per-worker-task. See
 [`docs/operations/observability-otel.md`](operations/observability-otel.md)
 for the full Jaeger/Tempo/Phoenix recipe.
+If you kept the RabbitMQ configuration from Step 5, also include `--extra rabbitmq`
+in the sync command. Do not use `make quickstart` here: it would remove the OTEL extra.
 
 ---
 
 ## Step 7 — Tests
 
 ```bash
-pytest tests/ -v
+make setup       # install development dependencies + admin/AWS extras and commit hooks
+make check-core  # fast local lint, format and core test checks
 ```
 
-Expected: all tests pass against SQLite in-memory. No external infra required.
+Run this after stopping the demo processes. These local checks do not require
+external infrastructure. Full integration checks have additional prerequisites;
+see [CONTRIBUTING.md](../CONTRIBUTING.md). `make setup` can remove optional extras
+from the preceding steps; reinstall the complete set if you need those services again.
 
 ```bash
 make test-pg    # optional: PostgreSQL variant
@@ -161,7 +186,7 @@ make test-dynamo  # optional: DynamoDB Local variant
 
 ## Next steps
 
-- [Build your own domain](tutorial/first-domain.md) — 10-minute guided walkthrough
+- [Build your own domain](tutorial/first-domain.md) — guided walkthrough
 - [AI-assisted scaffolding](ai-development.md) — `/new-domain` in Claude Code or Codex CLI
 - [Adoption guide](adoption.md) — partial import into an existing FastAPI project
 - [Frontend handoff](frontend-handoff.md) — OpenAPI contract, Orval codegen, JWT flow

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,76 +1,76 @@
-# How it compares
+# Choosing a backend foundation and collaboration workflow
 
-This page expands the README comparison with more detail, honest trade-offs,
-and the "why not X?" questions that come up on HN and Reddit.
+Use this guide to decide whether the blueprint fits your project. Evaluate the
+backend architecture and the repository-specific AI harness together: adopting
+both means learning the code structure and the process used to change it.
 
----
+<a id="how-it-compares"></a>
+<a id="feature-matrix"></a>
 
-## Feature matrix
+## What you gain, and what you take on
 
-| Feature | FastAPI Agent Blueprint | [tiangolo/full-stack](https://github.com/fastapi/full-stack-fastapi-template) | [s3rius/template](https://github.com/s3rius/FastAPI-template) | [teamhide/boilerplate](https://github.com/teamhide/fastapi-boilerplate) |
-|---|:-:|:-:|:-:|:-:|
-| Zero-boilerplate CRUD (8 methods) | **Yes** | No | No | No |
-| Auto domain discovery | **Yes** | No | No | No |
-| Architecture enforcement (pre-commit) | **Yes** | No | No | No |
-| AI workflow skills (Claude + Codex) | **15 + 15** | 0 | 0 | 0 |
-| Vector infrastructure (S3 Vectors) | **Yes** | No | No | No |
-| Multi-interface (API + Worker + Admin + MCP) | **3 + 1 planned** | 2 | 1 | 1 |
-| Architecture Decision Records | **29 active · 30 archived** | 0 | 0 | 0 |
-| Type-safe generics across layers | **Yes** | Partial | Partial | No |
-| IoC container DI | **Yes** | No | No | No |
-| JWT auth + RBAC | **Yes** | Yes | Partial | No |
-| Async worker integration | **Yes (Taskiq)** | No | No | Yes (Celery) |
-| Admin UI | **Yes (NiceGUI)** | Yes (SQLAdmin) | No | No |
-| OpenTelemetry | **Yes (opt-in)** | No | No | No |
-| AI Usage Ledger | **Yes** | No | No | No |
-| Pluggable DB backends | **4 (PG/MySQL/SQLite/DynamoDB)** | 1 (PG) | 2 (PG/SQLite) | 1 (PG) |
-| Vector store | **Yes (S3 Vectors + InMemory)** | No | No | No |
+| Need | What this blueprint offers | Adoption cost or boundary |
+|---|---|---|
+| Multiple business domains | Shared CRUD bases, domain discovery, and a consistent Router → Service → Repository path. | Learn the layer boundaries, DTO conventions, and dependency-injector wiring; a small API may not justify the structure. |
+| API, worker, and admin access to business logic | FastAPI, Taskiq, and NiceGUI surfaces around domain services. | Learn each interface's contracts and authentication requirements. The MCP server is still planned. |
+| A local evaluation before provisioning services | SQLite, InMemory infrastructure, and deterministic AI stubs. | Evaluation does not validate production capacity or model quality. Real deployments need infrastructure, credentials, and operational configuration. |
+| AI features without making them mandatory | Optional embedding, LLM, and RAG adapters and examples. | Select and configure provider extras, models, credentials, and storage appropriate to your service. |
+| Several contributors using AI coding tools | Shared rules and skills, a plan/execute workflow, checks, and review procedures across tool adapters. | Contributors must set up their tools and retain human review. Some workflow controls are reminders, not blocking checks. |
+| Continued architectural consistency | Import checks, documented contracts, review checklists, and guideline synchronization. | These controls require maintenance as your application changes; they do not prove every implementation is correct. |
 
----
+Start with the [backend demo](../README.md#quickstart) and the
+[API-change workflow](../README.md#ai-collaboration-harness). Try one domain
+change before deciding whether the conventions fit your team.
 
-## Why not Litestar or Robyn?
+<a id="when-not-to-use-this-blueprint"></a>
 
-**Litestar** is an excellent alternative with strong typing and a rich plugin system. Choose Litestar if:
-- You need first-class OpenAPI 3.1 (not 3.0)
-- You prefer the Litestar DI system over dependency-injector
+## When a different starting point may fit better
 
-Choose this blueprint if you want the FastAPI ecosystem (Pydantic v2, Starlette middleware, extensive community) with DDD structure on top.
+- **A small, single-purpose API:** a minimal FastAPI application can avoid
+  abstractions you do not yet need.
+- **A customer frontend included from day one:** inspect a full-stack starter
+  against your frontend, authentication, and deployment requirements. This
+  blueprint's admin UI serves operators, not your customer application.
+- **An established architecture you want to retain:** assess individual patterns
+  before copying shared infrastructure or adopting the full harness.
+- **A framework or raw-throughput decision:** benchmark your own workload and
+  compare deployment and ecosystem requirements. This repository is not a
+  comparative performance study.
+- **A standalone, framework-independent harness:** the rules and skills here
+  reference this repository's paths, layers, and commands. Extracting them needs
+  adaptation; a turnkey independent harness package is not provided.
 
-**Robyn** is a Rust-backed framework optimized for raw throughput. Choose Robyn if throughput at the edge is your primary constraint. This blueprint optimizes for developer velocity and architectural consistency, not raw requests/sec.
+<a id="why-not-litestar-or-robyn"></a>
+<a id="why-not-fastapifull-stack-fastapi-template"></a>
+<a id="why-not-cookiecutter-based-templates"></a>
 
----
+## Alternatives to explore
 
-## Why not `fastapi/full-stack-fastapi-template`?
+The links below are starting points, not feature rankings. Check the current
+documentation and code of each candidate for the capabilities you need.
 
-The official template is excellent for greenfield projects that need React frontend included. It does not include:
-- DDD modular layer separation
-- Zero-boilerplate CRUD generics
-- Pre-commit architecture enforcement
-- AI workflow skills
-- Multi-backend infrastructure (DynamoDB, S3 Vectors, etc.)
+| Decision | Official sources to inspect |
+|---|---|
+| Build a small FastAPI application yourself | [FastAPI tutorial](https://fastapi.tiangolo.com/tutorial/) |
+| Evaluate another template's structure and setup | [Full Stack FastAPI Template](https://github.com/fastapi/full-stack-fastapi-template), [s3rius/FastAPI-template](https://github.com/s3rius/FastAPI-template), [teamhide/fastapi-boilerplate](https://github.com/teamhide/fastapi-boilerplate) |
+| Compare Python web frameworks | [Litestar](https://docs.litestar.dev/), [Robyn](https://robyn.tech/) |
+| Generate a project from a configurable template | [Cookiecutter](https://cookiecutter.readthedocs.io/) |
 
-If you want a full-stack starter (frontend included), use `tiangolo/full-stack`. If you want a backend-focused DDD architecture with AI workflow acceleration, use this blueprint.
-
----
-
-## Why not cookiecutter-based templates?
-
-Cookiecutter templates generate a project once and then diverge. This blueprint is a **live template** — you can pull upstream improvements into your project via git. The pre-commit architecture enforcement and skill system also require the tooling files (AGENTS.md, `.claude/`, `.codex/`) to remain in the project, which a cookie-cutter approach would strip.
-
----
-
-## When NOT to use this blueprint
-
-- **Micro-service with one endpoint**: The DDD layer overhead is not worth it for a single-purpose service.
-- **You prefer FastAPI's native DI (Depends)**: This blueprint uses dependency-injector IoC container, which adds indirection. If you prefer Depends-everywhere, the cognitive overhead may not pay off.
-- **Frontend-included starter**: You need `tiangolo/full-stack` instead.
-- **Maximum throughput**: If you're benchmarking raw requests/sec, use Robyn or ASGI without the DDD layers.
-
----
+For every candidate, check: can the team understand one feature end-to-end,
+run it locally, verify changes, configure deployment, and maintain its chosen
+conventions? Feature counts alone do not answer those questions.
 
 ## Adoption paths
 
-This blueprint works for both greenfield and partial adoption:
+- **New project:** use the GitHub template, run the evaluation, then follow the
+  [first-domain tutorial](tutorial/first-domain.md).
+- **Existing project:** use the [adoption guide](adoption.md) to assess a gradual
+  introduction of patterns. Copying `_core` or the harness requires checking
+  dependencies and compatibility with your application's conventions.
+- **Manual or AI-assisted development:** both use the same backend structure.
+  The [tool guide](ai-development.md) adds AI collaboration to that foundation;
+  the [shared operating model](ai/shared/target-operating-model.md) explains
+  workflow responsibilities and exceptions.
 
-- **Greenfield**: Use the GitHub template button (`Use this template`) — you get the full structure.
-- **Partial import**: Copy `src/_core/` into your existing project and adopt one domain pattern at a time. See [`docs/adoption.md`](adoption.md) for the step-by-step guide.
+Treat future upstream changes as code to review against your own modifications,
+not as automatically safe template upgrades.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,19 +1,25 @@
-# Quickstart — run the blueprint in 60 seconds
+# Quickstart — run the backend locally
 
 Zero external infrastructure. No Docker. No Postgres. No cloud credentials.
-Just Python + `uv` + one command.
+Start with the backend, then explore the [AI collaboration workflow](../README.md#ai-collaboration-harness).
 
 ## Prerequisites
 
 - Python `>=3.12.9`
 - [`uv`](https://docs.astral.sh/uv/) (package manager)
+- Git and `make`; the demos also require `curl` and `python3` on your PATH
 
 ## Run it
 
 ```bash
-make setup         # first time only — create venv + install deps
-make quickstart    # boots FastAPI on SQLite + InMemory broker
+git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
+cd fastapi-agent-blueprint
+make quickstart    # installs dependencies, then runs the server in this terminal
 ```
+
+Use a fresh checkout for evaluation. `quickstart` syncs the admin extra and can
+remove other installed extras. `make setup` is for development dependencies
+(including admin + AWS) and commit hooks; it is not a prerequisite for this demo.
 
 The server comes up on `http://127.0.0.1:8001`:
 
@@ -31,10 +37,11 @@ For sharing the API with frontend developers, see
 
 ## Exercise the API
 
-In a second terminal:
+Keep the server running. In a second terminal, from the same repository directory:
 
 ```bash
 make demo
+make demo-rag
 ```
 
 This exercises the `auth` and `user` domains: health check → register (customer
@@ -49,6 +56,11 @@ admin the way the NiceGUI setup wizard would; it refuses to run in `stg`/`prod`.
 
 Raw script: [`scripts/demo.sh`](../scripts/demo.sh).
 
+`make demo-rag` exercises upload → chunk → embed → retrieve → answer with
+citations. The default embedder uses keyword matching and the answer agent
+returns a templated response: these are deterministic stubs, not external model
+calls. Both scripts check response success and exit with failure on a failed request.
+
 ## What does `quickstart` actually configure?
 
 `make quickstart` loads [`_env/quickstart.env`](../_env/quickstart.env.example)
@@ -60,7 +72,7 @@ Raw script: [`scripts/demo.sh`](../scripts/demo.sh).
 | `DATABASE_ENGINE` | `sqlite` → `./quickstart.db` |
 | `BROKER_TYPE` | `inmemory` (no queue server needed) |
 | `STORAGE_TYPE` | _(unset — object storage disabled)_ |
-| `LLM_PROVIDER` / `EMBEDDING_PROVIDER` | _(unset — AI features disabled)_ |
+| `LLM_PROVIDER` / `EMBEDDING_PROVIDER` | _(unset — RAG uses deterministic stubs)_ |
 | `ADMIN_BOOTSTRAP_USERNAME` / `ADMIN_BOOTSTRAP_PASSWORD` | `admin` / `admin` |
 
 On startup the server auto-creates the SQLite schema from `Base.metadata`
@@ -74,15 +86,21 @@ the DB-backed auth domain after the bootstrap user is created or promoted.
 
 ## Next steps
 
-- **Real local development** — copy `_env/local.env.example` to
-  `_env/local.env`, edit values, then run `make dev` (spins up PostgreSQL
-  via Docker Compose).
+- **Real local development** — stop the quickstart server, run `make setup`
+  to install development dependencies and commit hooks, then follow the
+  [PostgreSQL setup](reference.md#local-development-with-postgresql).
 - **Add a domain** — see [AGENTS.md](../AGENTS.md) and
   [docs/ai-development.md](ai-development.md), or invoke the
   `/new-domain` skill if you use Claude Code / Codex.
-- **Enable AI features** — set `LLM_PROVIDER` / `EMBEDDING_PROVIDER` (and
-  the matching credentials) in your env file. The `classification` domain
-  demonstrates the PydanticAI Agent integration.
+- **Enable real model calls** — stop the server, install the required provider
+  extras (for example, `uv sync --extra admin --extra pydantic-ai` for the base
+  AI integration), and set `LLM_PROVIDER` + `LLM_MODEL`,
+  `EMBEDDING_PROVIDER` + `EMBEDDING_MODEL`, and matching credentials in
+  `_env/quickstart.env`. Restart with
+  `uv run python run_server_local.py --env quickstart` so `make quickstart`
+  does not remove the extra you just installed. See the
+  [extras reference](reference.md#optional-dependency-extras) for provider-specific
+  extras and include every extra you want to retain in the sync command.
 
 ## Troubleshooting
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,7 +1,7 @@
 # Reference
 
 Deep details that used to live in the README. Start with the
-[60-second quickstart](quickstart.md) or the
+[quickstart](quickstart.md) or the
 [README](../README.md) for the high-level pitch; come here when you need
 environment specifics, the full tech stack, or a manual walkthrough.
 

--- a/docs/tutorial/first-domain.md
+++ b/docs/tutorial/first-domain.md
@@ -17,15 +17,14 @@ Whichever path you pick, the verification in [step 4](#step-4--verify-it-works) 
 ## Prerequisites
 
 - Python `>=3.12.9` and [`uv`](https://docs.astral.sh/uv/) installed
-- A clone of this repo with `make setup` already run (see [quickstart](../quickstart.md))
-- Expected time: **10 minutes**. No Docker, no PostgreSQL, no cloud credentials.
+- A fresh clone of this repo, with Git, `make`, and `curl` available
+- No Docker, PostgreSQL, or cloud credentials needed for the local walkthrough
 
 If you have not run the quickstart yet:
 
 ```bash
 git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
 cd fastapi-agent-blueprint
-make setup        # venv + deps via uv
 ```
 
 ---
@@ -33,11 +32,24 @@ make setup        # venv + deps via uv
 ## Step 1 — Start the blueprint in one terminal
 
 ```bash
-make quickstart   # SQLite + InMemory broker, FastAPI on :8001
+make quickstart   # installs dependencies; SQLite + InMemory broker on :8001
 ```
 
 Leave that running. Every command below runs in a *second* terminal
 from the repo root.
+
+`make quickstart` synchronizes the admin extra and can remove other extras.
+It does not install commit hooks. After confirming the demo boots, stop it with
+Ctrl+C. Install development dependencies and hooks, then restart directly:
+
+```bash
+make setup
+uv run python run_server_local.py --env quickstart
+```
+
+Leave that server running and use the second terminal for development. Direct
+restarts preserve the installed extras; another `make quickstart` would remove
+the AWS extra again.
 
 ---
 
@@ -372,7 +384,7 @@ Stop the running server (Ctrl+C in the first terminal), then restart it
 to re-create the SQLite schema with the new `order` table:
 
 ```bash
-rm -f ./quickstart.db && make quickstart
+uv run python run_server_local.py --env quickstart
 ```
 
 > The `order` table is auto-created at boot in `ENV=quickstart` mode


### PR DESCRIPTION
## Related Issue

Closes #421

## Change Summary

The README described backend features and harness assets without equally clear entry points, while its demo command chained a foreground server with requests that could never run alongside it. Both READMEs now introduce the backend and repository-specific AI collaboration harness as equal pillars, with separate navigation, concrete examples, adoption costs, and links to deeper documentation.

The comparison guide now explains selection trade-offs instead of unsupported competitor scorecards. Linked onboarding guides separate evaluation from development setup and preserve optional extras when restarting a server for real providers, RabbitMQ, or OTEL. Existing English and Korean README anchors are preserved. Runtime code, Makefile, API contracts, and harness policy are unchanged.

Sequential commits:
- `6c2ef74` — English and Korean README structure, examples, and navigation.
- `007e43e` — adoption criteria in place of feature scorecards.
- `edeb56b` — consistent setup and optional-dependency instructions across onboarding guides.

## Type of Change

- [x] docs: Documentation

## Checklist

- [x] Architecture rules followed; no source-layer changes.
- [x] Documented quickstart and both demos pass in a separate local clone.
- [x] Changed-file pre-commit checks and `git diff --check` pass.
- [x] Existing README heading anchors preserved in both languages.

## How to Test

- In a fresh checkout, run `make quickstart`; leave it running, then execute `make demo` and `make demo-rag` from another terminal in that directory. Both scripts exited 0 in an isolated local clone with SQLite and deterministic stubs.
- `python3 tools/check_doc_links.py`: 0 broken links across 192 Markdown files, 700 relative targets, and 98 anchors checked.
- `git diff --check origin/main...HEAD`: passed.
- `.venv/bin/pre-commit run --files README.md docs/README.ko.md docs/comparison.md docs/quickstart.md docs/adoption.md docs/canonical-demo.md docs/tutorial/first-domain.md docs/reference.md`: passed applicable hooks.
- Rendered both READMEs locally with Markdown tables and Mermaid, inspected them in the in-app browser, confirmed local images/diagrams loaded and the top backend/harness navigation worked. This was a local preview, not an assertion of pixel-identical GitHub rendering.

Local validation does not exercise external model providers, RabbitMQ, or OTEL collectors. Their updated install/restart instructions were checked against the existing extras and entrypoints. The full domain suite was not rerun locally for these documentation-only changes; PR CI supplies the repository checks.

## Review

Effect: the documentation presents both pillars and provides separate executable evaluation and development paths. It accurately distinguishes stub model output, planned MCP support, and blocking versus advisory harness controls.

Self-review and an additional read-only reviewer found no actionable findings. The reviewer checked the final diff against Makefile, demo scripts, runtime entrypoints, RAG stubs/selectors, shared workflow, and hook/CI configuration. All previous README anchors are retained. No drift candidates or guideline sync are required because the change describes existing behavior without modifying policy or harness assets.

## Governor Footer
- trigger: no
